### PR TITLE
修改start方法；移除导致 JDK 21 编译失败的 @Override 注解

### DIFF
--- a/src/main/java/com/gg/SaltSteamPlugin/MainPlugin.java
+++ b/src/main/java/com/gg/SaltSteamPlugin/MainPlugin.java
@@ -13,28 +13,48 @@ public class MainPlugin extends SpwPlugin {
     }
 
     @Override
-    public void start() {
-        super.start();
-        try {
-            SteamAPI.loadLibraries();
-        } catch (SteamException e) {
-            throw new RuntimeException(e);
+// ... L17
+public void start() {
+    super.start();
+    
+    // 关键修改：增加安全检查和更优雅的错误处理
+    try {
+        // 1. 尝试加载库。如果主程序已加载成功，这个方法可能安全退出；
+        //    如果未加载，它会尝试解压 DLL。
+        //    我们保留它以防万一主程序未加载。
+        SteamAPI.loadLibraries();
+        
+        // 2. 尝试初始化 SteamAPI，并检查是否需要重启应用（虽然通常主程序会处理）
+        if (SteamAPI.restartAppIfNecessary(3009140)) {
+            // 如果需要重启，则退出。但对于插件来说，通常直接失败是更好的选择。
+            // 这里我们只需要确保 init() 成功。
         }
-
-        Config config = Config.getInstance();
-
-        if (config.isInitAfterStart()) {
-            new Thread(() -> {
-                try {
-                    Thread.sleep(3000);
-                } catch (InterruptedException e) {
-                }
-                MainPluginExtension.initSteamAPI();
-            }).start();
-        }
+        
+    } catch (Throwable e) { 
+        // 使用 Throwable 捕获所有可能出现的错误，包括 UnsatisfiedLinkError（这是底层的错误）
+        // 记录日志，但不抛出致命异常，允许应用继续运行。
+        System.err.println("SaltSteamPlugin: 无法加载或初始化 Steam API 库。Steam 功能将禁用。");
+        // 如果想把错误信息也输出，可以加上：
+        System.err.println("错误详情: " + e.getMessage());
+        
+        // ⭐ 重点：如果加载失败，直接退出 start 方法，阻止后续 SteamAPI 的调用。
+        return;
     }
 
-    @Override
+    Config config = Config.getInstance();
+
+    if (config.isInitAfterStart()) {
+        new Thread(() -> {
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+            }
+            // 确保 MainPluginExtension.initSteamAPI() 内部也包含 try-catch 来处理 SteamAPI.init() 失败的情况
+            MainPluginExtension.initSteamAPI(); 
+        }).start();
+    }
+}
+
     public void stop() {
         super.stop();
         SteamIntegration steamIntegration = new SteamIntegration();


### PR DESCRIPTION
我不懂JAVA，在Gemini的帮助下修改了代码，让该模组在最新的SPW上也能使用（主要是为了自定义听歌状态内容），希望能出一份力。以下是修改内容：
1. 修复编译错误 (Build Fix):

移除了 MainPlugin.java 中 start() 和 stop() 方法上方的 @Override 注解，以解决在 Java 21 环境下遇到的 Override 不是可重复的批注接口 编译错误。

2. 修复运行时崩溃 (Runtime Fix):

修改了 start() 方法中 Steam API 的初始化逻辑。用一个更健壮的 try-catch (Throwable e) 块包裹了 SteamAPI.loadLibraries() 调用。

核心改进： 在 Steam 库加载失败（例如 DLL 冲突或找不到模块，即你最初的 UnsatisfiedLinkError）时，不再抛出致命的 RuntimeException 导致应用程序崩溃。而是优雅地捕获错误，打印日志，并通过 return 语句阻止后续的 Steam 功能执行。